### PR TITLE
chore: add Deno Deploy workflow

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy (Deno Deploy)
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
+    secrets: inherit
+    env:
+      STATIC_DIR: static/dist
+    with:
+      project: permit2-allowance-ubq-fi
+      preview_project: permit2-allowance-ubq-fi-preview
+      entrypoint: serve.ts
+      install_command: |
+        bun install
+      build_command: |
+        bun run build
+      env_var_keys: |
+        STATIC_DIR
+      bun_version: "1.1.x"
+      deno_version: v2.x
+      deployctl_version: "1.12.0"
+      prod_branch: development
+      include: |
+        static/**
+        build/**
+      exclude: |
+        node_modules
+        tests
+        cypress

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -9,8 +9,6 @@ jobs:
   deploy:
     uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
     secrets: inherit
-    env:
-      STATIC_DIR: static/dist
     with:
       project: permit2-allowance-ubq-fi
       preview_project: permit2-allowance-ubq-fi-preview
@@ -19,15 +17,12 @@ jobs:
         bun install
       build_command: |
         bun run build
-      env_var_keys: |
-        STATIC_DIR
       bun_version: "1.1.x"
       deno_version: v2.x
       deployctl_version: "1.12.0"
       prod_branch: development
       include: |
         static/**
-        build/**
       exclude: |
         node_modules
         tests

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -18,7 +18,7 @@ jobs:
       build_command: |
         bun run build
       bun_version: "1.1.x"
-      deno_version: v2.x
+      deno_version: 2.x
       deployctl_version: "1.12.0"
       prod_branch: development
       include: |

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "serve": "deno run --allow-read --allow-net serve.ts"
+    "serve": "deno run --allow-read --allow-net --allow-env serve.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "serve": "deno run --allow-read --allow-net serve.ts"
+  }
+}

--- a/serve.ts
+++ b/serve.ts
@@ -1,0 +1,5 @@
+import { serveDir } from "https://deno.land/std@0.224.0/http/file_server.ts";
+
+const root = Deno.env.get("STATIC_DIR") ?? "static/dist";
+
+Deno.serve((req) => serveDir(req, { fsRoot: root, quiet: true }));

--- a/serve.ts
+++ b/serve.ts
@@ -1,5 +1,5 @@
 import { serveDir } from "jsr:@std/http/file-server";
 
-const root = Deno.env.get("STATIC_DIR") ?? "static/dist";
+const root = Deno.env.get("STATIC_DIR") ?? "static";
 
 Deno.serve((req) => serveDir(req, { fsRoot: root, quiet: true }));

--- a/serve.ts
+++ b/serve.ts
@@ -1,4 +1,4 @@
-import { serveDir } from "https://deno.land/std@0.224.0/http/file_server.ts";
+import { serveDir } from "jsr:@std/http/file-server";
 
 const root = Deno.env.get("STATIC_DIR") ?? "static/dist";
 


### PR DESCRIPTION
## Summary
- add shared serve.ts + deno.json for Deno Deploy static hosting
- wire reusable org-level workflow for static/dist output

Resolves https://github.com/ubiquity/deno-deploy-workflow/issues/1

## Testing
- not run (CI will build/deploy)
